### PR TITLE
Update meta directive / drop request layer field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove "layer" from service directive for now,
+  because it is not yet implemented properly.
+  [jone]
 
 
 1.0a1 (2015-08-01)

--- a/src/plone/rest/zcml.py
+++ b/src/plone/rest/zcml.py
@@ -33,9 +33,8 @@ class IService(Interface):
         )
 
     factory = GlobalObject(
-        title=u"The factory for this behavior",
-        description=u"If this is not given, the behavior is assumed to " +
-                    u"provide a marker interface")
+        title=u"The factory for this service",
+        description=u"The factory is usually subclass of the Service class.")
 
     cors_enabled = Bool(
         title=u"The name of the view that should be the default."

--- a/src/plone/rest/zcml.py
+++ b/src/plone/rest/zcml.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from zope.configuration.exceptions import ConfigurationError
-from zope.configuration.fields import GlobalObject, GlobalInterface
+from zope.configuration.fields import GlobalObject
 from zope.interface import Interface
 from zope.schema import TextLine, Bool
 from zope.publisher.interfaces.browser import IBrowserPublisher
@@ -37,12 +37,6 @@ class IService(Interface):
         description=u"If this is not given, the behavior is assumed to " +
                     u"provide a marker interface")
 
-    layer = GlobalInterface(
-        title=u"A marker interface to be applied by the behavior",
-        description=u"If provides is given and factory is not given, then "
-                    u"this is optional",
-        required=False)
-
     cors_enabled = Bool(
         title=u"The name of the view that should be the default."
               u"[get|post|put|delete]",
@@ -73,7 +67,6 @@ def serviceDirective(
         method,
         factory,
         for_,
-        layer=None,
         cors_enabled=False,
         cors_origin=None,
         permission=CheckerPublic


### PR DESCRIPTION
- Update title / description of `factory` attribute in service directive interface (was mentioning behaviors, but we have services)
- Remove `layer` attribute from service directive: we cannot support browser layers since we use the request discriminator for determining the request method (`IGET`, `IPOST`, `IPUT`..)