### PR TITLE
Add support for named services.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
+- Add support for named services which allows registering services like
+  ``GET /Plone/search`` or ``GET /Plone/doc1/versions/1`` using a 'name' attribute.
+  [jone, lukasgraf, buchi]
+
 - Remove "layer" from service directive for now,
   because it is not yet implemented properly.
   [jone]

--- a/README.rst
+++ b/README.rst
@@ -133,6 +133,28 @@ OPTIONS::
   $ http --auth admin:admin OPTIONS localhost:8080/Plone/doc1 Accept:application/json
 
 
+Named Services
+--------------
+
+Named services can be registered by providing a 'name' attribute in the service directive:
+
+.. code-block:: xml
+
+  <plone:service
+    method="GET"
+    for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+    factory=".service.Search"
+    name="search"
+    />
+
+This registers a service endpoint accessible at the site root using the
+following request::
+
+  GET /Plone/search HTTP/1.1
+  Host: localhost:8080
+  Accept: application/json
+
+
 Installation
 ------------
 

--- a/src/plone/rest/configure.zcml
+++ b/src/plone/rest/configure.zcml
@@ -6,9 +6,8 @@
 
   <include file="meta.zcml"/>
   <subscriber
-    for="*
-         zope.app.publication.interfaces.IBeforeTraverseEvent"
-    handler=".events.btph_api_request"
+    for="ZPublisher.interfaces.IPubStart"
+    handler=".events.mark_as_api_request"
     />
 
   <include file="patches.zcml" />

--- a/src/plone/rest/demo.py
+++ b/src/plone/rest/demo.py
@@ -38,3 +38,39 @@ class Options(Service):
 
     def render(self):
         return {'service': 'options'}
+
+
+class NamedGet(Service):
+
+    def render(self):
+        return {'service': 'named get'}
+
+
+class NamedPost(Service):
+
+    def render(self):
+        return {'service': 'named post'}
+
+
+class NamedPut(Service):
+
+    def render(self):
+        return {'service': 'named put'}
+
+
+class NamedDelete(Service):
+
+    def render(self):
+        return {'service': 'named delete'}
+
+
+class NamedPatch(Service):
+
+    def render(self):
+        return {'service': 'named patch'}
+
+
+class NamedOptions(Service):
+
+    def render(self):
+        return {'service': 'named options'}

--- a/src/plone/rest/events.py
+++ b/src/plone/rest/events.py
@@ -9,25 +9,26 @@ from plone.rest.interfaces import IPATCH
 from zope.interface import alsoProvides
 
 
-def mark_as_api_request(request):
-    alsoProvides(request, IAPIRequest)
-    if request.get('REQUEST_METHOD') == 'PUT':
-        alsoProvides(request, IPUT)
-    if request.get('REQUEST_METHOD') == 'DELETE':
-        alsoProvides(request, IDELETE)
-    if request.get('REQUEST_METHOD') == 'GET':
-        alsoProvides(request, IGET)
-    if request.get('REQUEST_METHOD') == 'POST':
-        alsoProvides(request, IPOST)
-    if request.get('REQUEST_METHOD') == 'OPTIONS':
-        alsoProvides(request, IOPTIONS)
-    if request.get('REQUEST_METHOD') == 'PATCH':
-        alsoProvides(request, IPATCH)
-
-
-def btph_api_request(context, event):
+def mark_as_api_request(event):
     """Mark a request with Accept 'application/json' with the IAPIRequest
        interface.
     """
-    if event.request.getHeader('Accept') == 'application/json':
-        mark_as_api_request(event.request)
+    request = event.request
+    if request.getHeader('Accept') == 'application/json':
+        alsoProvides(request, IAPIRequest)
+        if request.get('REQUEST_METHOD') == 'PUT':
+            alsoProvides(request, IPUT)
+        if request.get('REQUEST_METHOD') == 'DELETE':
+            alsoProvides(request, IDELETE)
+        if request.get('REQUEST_METHOD') == 'GET':
+            alsoProvides(request, IGET)
+        if request.get('REQUEST_METHOD') == 'POST':
+            alsoProvides(request, IPOST)
+        if request.get('REQUEST_METHOD') == 'OPTIONS':
+            alsoProvides(request, IOPTIONS)
+        if request.get('REQUEST_METHOD') == 'PATCH':
+            alsoProvides(request, IPATCH)
+
+        # Flag as non-WebDAV request in order to avoid special treatment
+        # in ZPublisher.BaseRequest.traverse().
+        event.request.maybe_webdav_client = 0

--- a/src/plone/rest/patches.py
+++ b/src/plone/rest/patches.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from plone.rest.interfaces import IAPIRequest
-from plone.rest.events import mark_as_api_request
 from plone.dexterity.content import DexterityContent
 from Products.CMFPlone.Portal import PloneSite
 from zope.component.interfaces import ComponentLookupError
@@ -17,10 +16,6 @@ def PloneSite__before_publishing_traverse__(self, arg1, arg2=None):
     goon = True
 
     if IAPIRequest.providedBy(REQUEST):
-        goon = False
-
-    if goon and REQUEST.getHeader('Accept') == 'application/json':
-        mark_as_api_request(REQUEST)
         goon = False
 
     if not goon:

--- a/src/plone/rest/service.py
+++ b/src/plone/rest/service.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
+from Products.Five import BrowserView
 from ZPublisher.BaseRequest import DefaultPublishTraverse
 
 import json
 
 
-class Service(DefaultPublishTraverse):
+class Service(DefaultPublishTraverse, BrowserView):
 
     def __init__(self, context, request):
         self.context = context

--- a/src/plone/rest/testing.zcml
+++ b/src/plone/rest/testing.zcml
@@ -80,4 +80,48 @@
     factory=".demo.Options"
     />
 
+  <!-- Dexterity named services -->
+
+  <plone:service
+    method="GET"
+    for="plone.dexterity.interfaces.IDexterityContent"
+    factory=".demo.NamedGet"
+    name="namedservice"
+    />
+
+  <plone:service
+    method="POST"
+    for="plone.dexterity.interfaces.IDexterityContent"
+    factory=".demo.NamedPost"
+    name="namedservice"
+    />
+
+  <plone:service
+    method="PUT"
+    for="plone.dexterity.interfaces.IDexterityContent"
+    factory=".demo.NamedPut"
+    name="namedservice"
+    />
+
+  <plone:service
+    method="DELETE"
+    for="plone.dexterity.interfaces.IDexterityContent"
+    factory=".demo.NamedDelete"
+    name="namedservice"
+    />
+
+  <plone:service
+    method="PATCH"
+    for="plone.dexterity.interfaces.IDexterityContent"
+    factory=".demo.NamedPatch"
+    name="namedservice"
+    />
+
+  <plone:service
+    method="OPTIONS"
+    for="plone.dexterity.interfaces.IDexterityContent"
+    factory=".demo.NamedOptions"
+    name="namedservice"
+    />
+
 </configure>

--- a/src/plone/rest/tests/test_dexterity.py
+++ b/src/plone/rest/tests/test_dexterity.py
@@ -104,6 +104,78 @@ class TestDexterityServiceEndpoints(unittest.TestCase):
             response.json()
         )
 
+    def test_dexterity_named_get(self):
+        response = requests.get(
+            self.document.absolute_url() + '/namedservice',
+            headers={'Accept': 'application/json'},
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            {u'service': u'named get'},
+            response.json()
+        )
+
+    def test_dexterity_named_post(self):
+        response = requests.post(
+            self.document.absolute_url() + '/namedservice',
+            headers={'Accept': 'application/json'},
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            {u'service': u'named post'},
+            response.json()
+        )
+
+    def test_dexterity_named_put(self):
+        response = requests.put(
+            self.document.absolute_url() + '/namedservice',
+            headers={'Accept': 'application/json'},
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            {u'service': u'named put'},
+            response.json()
+        )
+
+    def test_dexterity_named_patch(self):
+        response = requests.patch(
+            self.document.absolute_url() + '/namedservice',
+            headers={'Accept': 'application/json'},
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            {u'service': u'named patch'},
+            response.json()
+        )
+
+    def test_dexterity_named_delete(self):
+        response = requests.delete(
+            self.document.absolute_url() + '/namedservice',
+            headers={'Accept': 'application/json'},
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            {u'service': u'named delete'},
+            response.json()
+        )
+
+    def test_dexterity_named_options(self):
+        response = requests.options(
+            self.document.absolute_url() + '/namedservice',
+            headers={'Accept': 'application/json'},
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            {u'service': u'named options'},
+            response.json()
+        )
+
     def test_dexterity_folder_get(self):
         self.portal.invokeFactory('Folder', id='folder')
         transaction.commit()

--- a/src/plone/rest/zcml.py
+++ b/src/plone/rest/zcml.py
@@ -36,6 +36,15 @@ class IService(Interface):
         title=u"The factory for this service",
         description=u"The factory is usually subclass of the Service class.")
 
+    name = TextLine(
+        title=u"The name of the service.",
+        description=u"""When no name is defined, the service is available at
+        the object's absolute URL. When defining a name, the service is
+        available at the object's absolute URL appended with a slash and the
+        service name.""",
+        required=False,
+        default=u'')
+
     cors_enabled = Bool(
         title=u"The name of the view that should be the default."
               u"[get|post|put|delete]",
@@ -66,6 +75,7 @@ def serviceDirective(
         method,
         factory,
         for_,
+        name=u'',
         cors_enabled=False,
         cors_origin=None,
         permission=CheckerPublic
@@ -106,12 +116,14 @@ def serviceDirective(
             _context,
             factory=(get_cors_preflight_view),
             provides=IBrowserPublisher,
-            for_=(for_, interfaces.IOPTIONS)
+            for_=(for_, interfaces.IOPTIONS),
+            name=name,
         )
 
     adapter(
         _context,
         factory=(factory,),
         provides=IBrowserPublisher,
-        for_=(for_, marker)
+        for_=(for_, marker),
+        name=name,
     )


### PR DESCRIPTION
- Named services behave like browser views, thus we inherit from `P.Five.BrowserView`
  to pass security checks in ZPublisher traversal.
- We flag API requests as non-WebDAV requests to avoid special treatment in
  ZPublisher traversal which prevents named services to work with methods other than `GET`, `POST` and `PURGE`.
- Move marking of requests to IPubStart event as we need to set the non-WebDAV
  flag before traversal starts.

(Also see discussion in #16)