### PR TITLE
implement standard error handling.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Render errors as JSON.
+  [jone]
 
 
 1.0a1 (2015-08-01)

--- a/src/plone/rest/configure.zcml
+++ b/src/plone/rest/configure.zcml
@@ -13,4 +13,10 @@
 
   <include file="patches.zcml" />
 
+  <adapter
+      factory=".errors.ErrorHandling"
+      name="index.html"
+      provides="zope.interface.Interface"
+      />
+
 </configure>

--- a/src/plone/rest/errors.py
+++ b/src/plone/rest/errors.py
@@ -11,8 +11,19 @@ class ErrorHandling(BrowserView):
         exception = self.context
         data = self.render_exception(exception)
         result = json.dumps(data, indent=2, sort_keys=True)
-        self.request.response.setHeader('Content-Type', 'application/json')
-        return result
+
+        # Write and lock the response in order to avoid later changes
+        # especially for Unauthorized exceptions.
+        response = self.request.response
+        response.setHeader('Content-Type', 'application/json')
+        response.setStatus(type(exception), lock=1)
+        response.setBody(result, lock=1)
+
+        # Avoid redirect to login page on Unauthorized by adding
+        # a fake challenged flag, which makes the PAS believe it
+        # already did challenge and redirect.
+        response._has_challenged = True
+        return
 
     def render_exception(self, exception):
         return {u'type': type(exception).__name__.decode('utf-8'),

--- a/src/plone/rest/errors.py
+++ b/src/plone/rest/errors.py
@@ -1,0 +1,19 @@
+from plone.rest.interfaces import IAPIRequest
+from Products.Five.browser import BrowserView
+from zope.component import adapter
+import json
+
+
+@adapter(Exception, IAPIRequest)
+class ErrorHandling(BrowserView):
+
+    def __call__(self):
+        exception = self.context
+        data = self.render_exception(exception)
+        result = json.dumps(data, indent=2, sort_keys=True)
+        self.request.response.setHeader('Content-Type', 'application/json')
+        return result
+
+    def render_exception(self, exception):
+        return {u'type': type(exception).__name__.decode('utf-8'),
+                u'message': str(exception).decode('utf-8')}

--- a/src/plone/rest/tests/test_error_handling.py
+++ b/src/plone/rest/tests/test_error_handling.py
@@ -78,6 +78,8 @@ class TestErrorHandling(unittest.TestCase):
             'When sending a GET request with Accept: application/json ' +
             'the server should respond with sending back application/json.'
         )
+        self.assertNotIn('Location', response.headers,
+                         'A 401 unauthorized should not redirect.')
         self.assertTrue(json.loads(response.content))
         self.assertEqual(
             'Unauthorized',

--- a/src/plone/rest/tests/test_error_handling.py
+++ b/src/plone/rest/tests/test_error_handling.py
@@ -111,3 +111,8 @@ class TestErrorHandling(unittest.TestCase):
             'HTTPError',
             response.json()['type']
         )
+
+        self.assertEqual(
+            {u'type': u'HTTPError',
+             u'message': u'HTTP Error 500: InternalServerError'},
+            response.json())


### PR DESCRIPTION
:grey_exclamation: base and target branch is `error-handling`  for inclusion in #13 :grey_exclamation: 

I've started implementing JSON error handling by providing an `index.html` adapter for exceptions.
This works quite well, but not for `Unauthorized` exceptions.

**1) Unauthorized is tricky**
The unauthorized exception is the only exception which is re-raised ([here](https://github.com/zopefoundation/Zope/blob/2.13.23/src/Zope2/App/startup.py#L231-L236)).
The exception is handled different than any other exceptions: mainly the PAS is asked and it leads to a redirect to the `login_form`.
I can suppress the redirect, but I'm unable to render non-HTML response since I'm not in control of that anymore.

My approach for fixing that is below, but it does not work, it only prevents redirecting:
```python
        if isinstance(exception, Unauthorized):
            response.setStatus(type(exception))
            response.setBody(result)
            # Avoid redirect to login page on 404s by adding challenged flag
            response._has_challenged = True
            return
```

**2. Show exception to non-privileged users?**
In non-api Plone, the exception details are only rendered to privileged users. Anonymous / unprivileged users only get an "An error occured" and an error number.
How do we want to handle that in the API?
(I did not yet implement anything).

/cc @tisto @bloodbare @lukasgraf @buchi 