### PR TITLE
Cleanup patch of DynamicType pre-traversal hook and add tests.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
+- Simplify patch of DynamicType pre-traversal hook and actually make it work
+  with Archetypes.
+  [buchi]
+
 - Render errors as JSON.
   [jone]
 

--- a/src/plone/rest/patches.py
+++ b/src/plone/rest/patches.py
@@ -1,72 +1,15 @@
 # -*- coding: utf-8 -*-
 from plone.rest.interfaces import IAPIRequest
-from plone.dexterity.content import DexterityContent
-from Products.CMFPlone.Portal import PloneSite
-from zope.component.interfaces import ComponentLookupError
-from zope.event import notify
-from zope.traversing.interfaces import BeforeTraverseEvent
 
 
-def PloneSite__before_publishing_traverse__(self, arg1, arg2=None):
+def __before_publishing_traverse__(self, arg1, arg2=None):
     """Pre-traversal hook that stops traversal to prevent the default view
-       to be appended. Appending the default view will break REST calls.
+       to be appended. Appending the default view would break REST calls.
     """
+    # XXX hack around a bug(?) in BeforeTraverse.MultiHook
     REQUEST = arg2 or arg1
 
-    goon = True
-
     if IAPIRequest.providedBy(REQUEST):
-        goon = False
-
-    if not goon:
-        # Copied of CMFCore PortalObject
-        try:
-            notify(BeforeTraverseEvent(self, REQUEST))
-        except ComponentLookupError:
-            # allow ZMI access, even if the portal's site manager is missing
-            pass
         return
 
-    super(PloneSite, self).__before_publishing_traverse__(
-        arg1, arg2)
-
-
-def DexterityContent__before_publishing_traverse__(self, arg1, arg2=None):
-        """Pre-traversal hook that stops traversal to prevent the default view
-           to be appended. Appending the default view will break REST calls.
-        """
-        REQUEST = arg2 or arg1
-
-        from plone.rest.interfaces import IAPIRequest
-        if IAPIRequest.providedBy(REQUEST):
-            # Copied of CMFCore PortalObject
-            try:
-                notify(BeforeTraverseEvent(self, REQUEST))
-            except ComponentLookupError:
-                # allow ZMI access, even if the portal's site manager is
-                # missing
-                pass
-            return
-        super(DexterityContent, self).__before_publishing_traverse__(
-            arg1, arg2)
-
-
-def ArchetypesContent__before_publishing_traverse__(self, arg1, arg2=None):
-        """Pre-traversal hook that stops traversal to prevent the default view
-           to be appended. Appending the default view will break REST calls.
-        """
-        REQUEST = arg2 or arg1
-
-        from plone.rest.interfaces import IAPIRequest
-        if IAPIRequest.providedBy(REQUEST):
-            # Copied of CMFCore PortalObject
-            try:
-                notify(BeforeTraverseEvent(self, REQUEST))
-            except ComponentLookupError:
-                # allow ZMI access, even if the portal's site manager is
-                # missing
-                pass
-            return
-
-        super(DexterityContent, self).__before_publishing_traverse__(
-            arg1, arg2)
+    return self._old___before_publishing_traverse__(arg1, arg2)

--- a/src/plone/rest/patches.zcml
+++ b/src/plone/rest/patches.zcml
@@ -6,24 +6,11 @@
   <include package="collective.monkeypatcher" />
 
   <monkey:patch
-    description=""
-    class="Products.CMFPlone.Portal.PloneSite"
+    description="Disables DynamicType traversal hook for REST requests."
+    class="Products.CMFCore.DynamicType.DynamicType"
     original="__before_publishing_traverse__"
-    replacement=".patches.PloneSite__before_publishing_traverse__"
-    />
-
-  <monkey:patch
-    description=""
-    class="plone.dexterity.content.DexterityContent"
-    original="__before_publishing_traverse__"
-    replacement=".patches.DexterityContent__before_publishing_traverse__"
-    />
-
-  <monkey:patch
-    description=""
-    class="plone.dexterity.content.Container"
-    original="__before_publishing_traverse__"
-    replacement=".patches.DexterityContent__before_publishing_traverse__"
+    replacement=".patches.__before_publishing_traverse__"
+    preserveOriginal="true"
     />
 
 </configure>

--- a/src/plone/rest/tests/test_traversal.py
+++ b/src/plone/rest/tests/test_traversal.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+from ZPublisher.pubevents import PubStart
+from base64 import b64encode
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.rest.service import Service
+from plone.rest.testing import PLONE_REST_INTEGRATION_TESTING
+from zope.event import notify
+
+import unittest
+
+
+class TestTraversal(unittest.TestCase):
+
+    layer = PLONE_REST_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+
+    def traverse(self, path='/plone', accept='application/json', method='GET'):
+        request = self.layer['request']
+        request.environ['PATH_INFO'] = path
+        request.environ['PATH_TRANSLATED'] = path
+        request.environ['HTTP_ACCEPT'] = accept
+        request.environ['REQUEST_METHOD'] = method
+        request._auth = 'Basic %s' % b64encode(
+            '%s:%s' % (SITE_OWNER_NAME, SITE_OWNER_PASSWORD))
+        notify(PubStart(request))
+        return request.traverse(path)
+
+    def test_json_request_on_portal_root_returns_service(self):
+        obj = self.traverse()
+        self.assertTrue(isinstance(obj, Service), 'Not a service')
+
+    def test_json_request_on_portal_root_with_layout_returns_service(self):
+        self.portal.setLayout('summary_view')
+        obj = self.traverse()
+        self.assertTrue(isinstance(obj, Service), 'Not a service')
+
+    def test_json_request_on_portal_root_with_default_page_returns_service(
+            self):
+        self.portal.invokeFactory('Document', id='doc1')
+        self.portal.setDefaultPage('doc1')
+        obj = self.traverse()
+        self.assertTrue(isinstance(obj, Service), 'Not a service')
+
+    def test_json_request_on_content_object_returns_service(self):
+        self.portal.invokeFactory('Document', id='doc1')
+        obj = self.traverse(path='/plone/doc1')
+        self.assertTrue(isinstance(obj, Service), 'Not a service')
+
+    def test_html_request_on_portal_root_returns_default_view(self):
+        obj = self.traverse(accept='text/html')
+        self.assertEquals('listing_view', obj.__name__)
+
+    def test_html_request_on_portal_root_returns_dynamic_view(self):
+        self.portal.setLayout('summary_view')
+        obj = self.traverse(accept='text/html')
+        self.assertEquals('summary_view', obj.__name__)
+
+    def test_html_request_on_portal_root_returns_default_page(self):
+        self.portal.invokeFactory('Document', id='doc1')
+        self.portal.setDefaultPage('doc1')
+        obj = self.traverse(accept='text/html')
+        self.assertEquals('document_view', obj.__name__)


### PR DESCRIPTION
Before cleanup there were 3 patches doing the same for the portal root, Dexterity content and Archetypes content. Patching was done in the wrong place by adding additional pre-traversal hooks on these classes.
Now we patch the pre-traversal hook of `Products.CMFCore.DynamicType.DynamicType` directly which greatly simplifies the patch as the involved content classes all inherit from the `DynamicType` mixin.

The patch prevents appending the default view during traversal as this would break REST requests.

@lukasgraf 
/cc @tisto @bloodbare 