### PR TITLE
Traversal refactoring

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 1.0a4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Refactor traversal of REST requests by using a traversal adapter on the site
+  root instead of a traversal adapter for each REST service. This prevents
+  REST services from being overriden by other traversal adapters.
+  [buchi]
 
 
 1.0a3 (2015-12-16)

--- a/src/plone/rest/configure.zcml
+++ b/src/plone/rest/configure.zcml
@@ -12,6 +12,8 @@
 
   <include file="patches.zcml" />
 
+  <adapter factory=".traverse.RESTTraverse" />
+
   <adapter
       factory=".errors.ErrorHandling"
       name="index.html"

--- a/src/plone/rest/service.py
+++ b/src/plone/rest/service.py
@@ -1,21 +1,10 @@
 # -*- coding: utf-8 -*-
 from Products.Five import BrowserView
-from ZPublisher.BaseRequest import DefaultPublishTraverse
 
 import json
 
 
-class Service(DefaultPublishTraverse, BrowserView):
-
-    def __init__(self, context, request):
-        self.context = context
-        self.request = request
-
-    def browserDefault(self, request):
-        return self, None
-
-    def publishTraverse(self, request, name):
-        return super(Service, self).publishTraverse(request, name)
+class Service(BrowserView):
 
     def __call__(self):
         self.request.response.setHeader("Content-Type", "application/json")

--- a/src/plone/rest/testing.py
+++ b/src/plone/rest/testing.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE
-from plone.app.testing import PloneSandboxLayer
-from plone.app.testing import IntegrationTesting
 from plone.app.testing import FunctionalTesting
+from plone.app.testing import IntegrationTesting
+from plone.app.testing import PloneSandboxLayer
+from plone.rest.service import Service
 from plone.testing import z2
-from Products.Five.browser import BrowserView
 
 from zope.configuration import xmlconfig
 
@@ -38,7 +38,7 @@ PLONE_REST_FUNCTIONAL_TESTING = FunctionalTesting(
 )
 
 
-class InternalServerErrorView(BrowserView):
+class InternalServerErrorService(Service):
 
     def __call__(self):
         from urllib2 import HTTPError

--- a/src/plone/rest/testing.zcml
+++ b/src/plone/rest/testing.zcml
@@ -126,11 +126,11 @@
 
   <!-- Error Page -->
 
-  <browser:page
+  <plone:service
+    method="GET"
     for="*"
     name="500-internal-server-error"
-    class=".testing.InternalServerErrorView"
-    permission="zope2.View"
+    factory=".testing.InternalServerErrorService"
     />
 
 </configure>

--- a/src/plone/rest/traverse.py
+++ b/src/plone/rest/traverse.py
@@ -44,6 +44,7 @@ class RESTWrapper(object):
     def __init__(self, context, request):
         self.context = context
         self.request = request
+        self._bpth_called = False
 
     def __getattr__(self, name):
         # Delegate attribute access to the wrapped object
@@ -53,6 +54,14 @@ class RESTWrapper(object):
     def __getitem__(self, name):
         # Delegate key access to the wrapped object
         return self.context[name]
+
+    # MultiHook requries this to be a class attribute
+    def __before_publishing_traverse__(self, arg1, arg2=None):
+        bpth = getattr(self.context, '__before_publishing_traverse__', False)
+        if bpth:
+            if not self._bpth_called:
+                self._bpth_called = True
+                bpth(arg1, arg2)
 
     def publishTraverse(self, request, name):
         # Try to get an object using default traversal

--- a/src/plone/rest/traverse.py
+++ b/src/plone/rest/traverse.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
+from ZPublisher.BaseRequest import DefaultPublishTraverse
+from plone.rest.interfaces import IAPIRequest
+from zope.component import adapts
+from zope.component import queryMultiAdapter
+from zope.interface import implements
+from zope.publisher.interfaces.browser import IBrowserPublisher
+
+NAME_PREFIX = u'rest_'
+
+
+class RESTTraverse(DefaultPublishTraverse):
+    adapts(IPloneSiteRoot, IAPIRequest)
+
+    def publishTraverse(self, request, name):
+        try:
+            obj = super(RESTTraverse, self).publishTraverse(request, name)
+        except KeyError:
+            # No object, maybe a named rest service
+            service = queryMultiAdapter((self.context, request),
+                                        name=NAME_PREFIX + name)
+            if service is None:
+                raise
+            return service
+
+        if name.startswith(NAME_PREFIX):
+            return obj
+
+        # Wrap object to ensure we handle further traversal
+        return RESTWrapper(obj, request)
+
+    def browserDefault(self, request):
+        # Called when we have reached the end of the path
+        # In our case this means an unamed service
+        return self.context, (NAME_PREFIX,)
+
+
+class RESTWrapper(object):
+    """A wrapper for objects traversed during a REST request.
+    """
+    implements(IBrowserPublisher)
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def __getattr__(self, name):
+        # Delegate attribute access to the wrapped object
+        # Needed for security checks in ZPublisher traversal
+        return getattr(self.context, name)
+
+    def __getitem__(self, name):
+        # Delegate key access to the wrapped object
+        return self.context[name]
+
+    def publishTraverse(self, request, name):
+        # Try to get an object using default traversal
+        adapter = DefaultPublishTraverse(self.context, request)
+        try:
+            obj = adapter.publishTraverse(request, name)
+
+        # If there's no object with the given name, we get a KeyError.
+        # In a non-folderish context a key lookup results in an AttributeError.
+        except (KeyError, AttributeError):
+            # No object, maybe a named rest service
+            service = queryMultiAdapter((self.context, request),
+                                        name=NAME_PREFIX + name)
+            if service is None:
+                raise
+            return service
+        else:
+            # Wrap object to ensure we handle further traversal
+            return RESTWrapper(obj, request)
+
+    def browserDefault(self, request):
+        # Called when we have reached the end of the path
+        # In our case this means an unamed service
+        return self.context, (NAME_PREFIX,)

--- a/src/plone/rest/zcml.py
+++ b/src/plone/rest/zcml.py
@@ -6,6 +6,7 @@ from zope.schema import TextLine, Bool
 from zope.publisher.interfaces.browser import IBrowserPublisher
 from plone.rest import interfaces
 from plone.rest.cors import get_cors_preflight_view
+from plone.rest.traverse import NAME_PREFIX
 
 from zope.component.zcml import adapter
 from zope.security.zcml import Permission
@@ -117,7 +118,7 @@ def serviceDirective(
             factory=(get_cors_preflight_view),
             provides=IBrowserPublisher,
             for_=(for_, interfaces.IOPTIONS),
-            name=name,
+            name=NAME_PREFIX + name,
         )
 
     adapter(
@@ -125,5 +126,5 @@ def serviceDirective(
         factory=(factory,),
         provides=IBrowserPublisher,
         for_=(for_, marker),
-        name=name,
+        name=NAME_PREFIX + name,
     )


### PR DESCRIPTION
As already discussed in #26 and probably experienced in #27 the current traversal implementation for REST services does not work in situations when another IPublishTraverse adapter takes precedence. 

Especially registering a service for a very unspecific context like
```
<plone:service
   for="*"
   name="search"
   method="GET"
/>
```
will result in not working REST services because other traversal adapters are more specific for some contexts.

To address this issue i've reimplemented traversal for REST requests the following way:
- Implement a traversal adapter on the site root for REST requests
- Any traversed object is wrapped with a special traversal aware wrapper that handles further traversal
- Services no longer implement IPublishTraverse but are simple browser views.
- To make sure we do not conflict with other browser views, the name of a REST service is prefixed with `'rest_'`. 

Fixes #26 

/cc @tisto @bloodbare @lukasgraf 