### PR TITLE
Implement content negotiation.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 1.0a4 (unreleased)
 ------------------
 
+- Add support for content negotiation. REST services are no longer hardwired
+  to 'application/json' Accept headers. Instead the media type can be
+  configured with the service directive.
+  [buchi]
+
 - Refactor traversal of REST requests by using a traversal adapter on the site
   root instead of a traversal adapter for each REST service. This prevents
   REST services from being overriden by other traversal adapters.

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Features
   * OPTIONS
 
 * Support for Dexterity and Archetypes-based content objects
-* Content negotiation ('application/json' is currently the only format supported).
+* Content negotiation: Services can be registered for arbitrary media types (e.g. 'application/json').
 * Named services allows to register service endpoints for custom URLs
 
 
@@ -79,11 +79,14 @@ This is how you would register a PATCH request on Dexterity content:
 
   <plone:service
     method="PATCH"
+    accept="application/json"
     for="plone.dexterity.interfaces.IDexterityContent"
     factory=".service.Patch"
     />
 
-You have to specify the HTTP verb (GET, POST, PUT, DELETE, HEAD, OPTIONS), the interface for the content objects and the factory class that actually returns the content.
+You have to specify the HTTP verb (GET, POST, PUT, DELETE, HEAD, OPTIONS), the
+media type used for content negotiation, the interface for the content objects
+and the factory class that actually returns the content.
 
 The factory class needs to inherit from the plone.rest 'Service' class and to implement a render method that returns a list or a dict::
 
@@ -160,6 +163,7 @@ Named services can be registered by providing a 'name' attribute in the service 
 
   <plone:service
     method="GET"
+    accept="application/json"
     for="Products.CMFPlone.interfaces.IPloneSiteRoot"
     factory=".service.Search"
     name="search"

--- a/src/plone/rest/events.py
+++ b/src/plone/rest/events.py
@@ -1,34 +1,41 @@
 # -*- coding: utf-8 -*-
 from plone.rest.interfaces import IAPIRequest
-from plone.rest.interfaces import IPUT
-from plone.rest.interfaces import IGET
-from plone.rest.interfaces import IPOST
 from plone.rest.interfaces import IDELETE
+from plone.rest.interfaces import IGET
 from plone.rest.interfaces import IOPTIONS
 from plone.rest.interfaces import IPATCH
+from plone.rest.interfaces import IPOST
+from plone.rest.interfaces import IPUT
+from plone.rest.negotiation import lookup_service_id
 from zope.interface import alsoProvides
 
 
 def mark_as_api_request(event):
-    """Mark a request with Accept 'application/json' with the IAPIRequest
-       interface.
+    """Mark a request as IAPIRequest if there's a service registered for the
+       actual request method and Accept header.
     """
     request = event.request
-    if request.getHeader('Accept') == 'application/json':
+    method = request.get('REQUEST_METHOD', 'GET')
+    accept = request.getHeader('Accept', 'text/html')
+    service_id = lookup_service_id(method, accept)
+
+    if service_id is not None:
         alsoProvides(request, IAPIRequest)
-        if request.get('REQUEST_METHOD') == 'PUT':
-            alsoProvides(request, IPUT)
-        if request.get('REQUEST_METHOD') == 'DELETE':
+        request._rest_service_id = service_id
+
+        if method == 'DELETE':
             alsoProvides(request, IDELETE)
-        if request.get('REQUEST_METHOD') == 'GET':
+        elif method == 'GET':
             alsoProvides(request, IGET)
-        if request.get('REQUEST_METHOD') == 'POST':
-            alsoProvides(request, IPOST)
-        if request.get('REQUEST_METHOD') == 'OPTIONS':
+        elif method == 'OPTIONS':
             alsoProvides(request, IOPTIONS)
-        if request.get('REQUEST_METHOD') == 'PATCH':
+        elif method == 'PATCH':
             alsoProvides(request, IPATCH)
+        elif method == 'POST':
+            alsoProvides(request, IPOST)
+        elif method == 'PUT':
+            alsoProvides(request, IPUT)
 
         # Flag as non-WebDAV request in order to avoid special treatment
         # in ZPublisher.BaseRequest.traverse().
-        event.request.maybe_webdav_client = 0
+        request.maybe_webdav_client = 0

--- a/src/plone/rest/negotiation.py
+++ b/src/plone/rest/negotiation.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+NAME_PREFIX = u'rest'
+
+# Service registry
+# A mapping of method -> type name -> subtype name -> service id
+_services = {}
+
+
+def parse_accept_header(accept):
+    """Parse the given Accept header ignoring any parameters and return a list
+       of media type tuples.
+    """
+    media_types = []
+    for media_range in accept.split(','):
+        media_type = media_range.split(';')[0].strip()
+        if '/' in media_type:
+            type_, subtype = media_type.split('/')
+            media_types.append((type_, subtype))
+    return media_types
+
+
+def lookup_service_id(method, accept):
+    """Lookup the service id for the given request method and Accept header.
+       Only Accept headers containing exactly one media type are considered for
+       negotiation.
+    """
+    media_types = parse_accept_header(accept)
+    if len(media_types) != 1:
+        return None
+    type_, subtype = media_types[0]
+    types = _services.get(method, {})
+    subtypes = types.get(type_, {})
+    if subtype in subtypes:
+        return subtypes[subtype]
+    elif '*' in subtypes:
+        return subtypes['*']
+    if '*' in types:
+        return types['*']['*']
+    return None
+
+
+def register_service(method, media_type):
+    """Register a service for the given request method and media type and
+       return it's service id.
+    """
+    service_id = u'{}_{}_{}'.format(NAME_PREFIX, media_type[0], media_type[1])
+    types = _services.setdefault(method, {})
+    subtypes = types.setdefault(media_type[0], {})
+    subtypes[media_type[1]] = service_id
+    return service_id

--- a/src/plone/rest/tests/test_negotiation.py
+++ b/src/plone/rest/tests/test_negotiation.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+from plone.rest.negotiation import lookup_service_id
+from plone.rest.negotiation import parse_accept_header
+from plone.rest.negotiation import register_service
+
+import unittest
+
+
+class TestAcceptHeaderParser(unittest.TestCase):
+
+    def test_parse_application_json_accept_header(self):
+        accept = 'application/json'
+        expected = [('application', 'json')]
+        self.assertEqual(expected, parse_accept_header(accept))
+
+    def test_parse_jquery_json_accept_header(self):
+        accept = ('text/javascript, application/javascript, '
+                  'application/ecmascript, application/x-ecmascript, '
+                  '*/*; q=0.01')
+        expected = [('text', 'javascript'),
+                    ('application', 'javascript'),
+                    ('application', 'ecmascript'),
+                    ('application', 'x-ecmascript'),
+                    ('*', '*')]
+        self.assertEqual(expected, parse_accept_header(accept))
+
+    def test_parse_firefox_accept_header(self):
+        accept = ('text/html,application/xhtml+xml,application/xml;q=0.9,'
+                  '*/*;q=0.8')
+        expected = [('text', 'html'),
+                    ('application', 'xhtml+xml'),
+                    ('application', 'xml'),
+                    ('*', '*')]
+        self.assertEqual(expected, parse_accept_header(accept))
+
+    def test_parse_chrome_accept_header(self):
+        accept = ('text/html,application/xhtml+xml,application/xml;q=0.9,'
+                  'image/webp,*/*;q=0.8')
+        expected = [('text', 'html'),
+                    ('application', 'xhtml+xml'),
+                    ('application', 'xml'),
+                    ('image', 'webp'),
+                    ('*', '*')]
+        self.assertEqual(expected, parse_accept_header(accept))
+
+    def test_parse_all_media_types_accept_header(self):
+        self.assertEqual([('*', '*')], parse_accept_header('*/*'))
+
+    def test_parse_invalid_accept_header(self):
+        self.assertEqual([], parse_accept_header('invalid'))
+
+
+class TestServiceRegistry(unittest.TestCase):
+
+    def test_register_media_type(self):
+        self.assertEqual('rest_application_json',
+                         register_service('GET', ('application', 'json')))
+        self.assertEqual('rest_application_json',
+                         lookup_service_id('GET', 'application/json'))
+
+    def test_register_wildcard_subtype(self):
+        self.assertEqual('rest_text_*',
+                         register_service('PATCH', ('text', '*')))
+        self.assertEqual('rest_text_*', lookup_service_id('PATCH', 'text/xml'))
+
+    def test_register_wilcard_type(self):
+        self.assertEqual('rest_*_*', register_service('PATCH', ('*', '*')))
+        self.assertEqual('rest_*_*', lookup_service_id('PATCH', 'foo/bar'))
+
+    def test_service_id_for_multiple_media_types_is_none(self):
+        register_service('GET', 'application/json')
+        self.assertEqual(None, lookup_service_id(
+            'GET', 'application/json,application/javascipt'))
+
+    def test_service_id_for_invalid_media_type_is_none(self):
+        self.assertEqual(None, lookup_service_id('GET', 'application-json'))
+
+    def test_service_id_for_not_registered_media_type_is_none(self):
+        self.assertEqual(None, lookup_service_id('PUT', 'text/html'))
+
+    def test_service_id_for_wildcard_type_is_none(self):
+        register_service('GET', 'application/json')
+        self.assertEqual(None, lookup_service_id('GET', '*/*'))
+
+    def test_service_id_for_wildcard_subtype_is_none(self):
+        register_service('GET', 'text/xml')
+        self.assertEqual(None, lookup_service_id('GET', 'text/*'))

--- a/src/plone/rest/traverse.py
+++ b/src/plone/rest/traverse.py
@@ -7,8 +7,6 @@ from zope.component import queryMultiAdapter
 from zope.interface import implements
 from zope.publisher.interfaces.browser import IBrowserPublisher
 
-NAME_PREFIX = u'rest_'
-
 
 class RESTTraverse(DefaultPublishTraverse):
     adapts(IPloneSiteRoot, IAPIRequest)
@@ -19,12 +17,12 @@ class RESTTraverse(DefaultPublishTraverse):
         except KeyError:
             # No object, maybe a named rest service
             service = queryMultiAdapter((self.context, request),
-                                        name=NAME_PREFIX + name)
+                                        name=request._rest_service_id + name)
             if service is None:
                 raise
             return service
 
-        if name.startswith(NAME_PREFIX):
+        if name.startswith(request._rest_service_id):
             return obj
 
         # Wrap object to ensure we handle further traversal
@@ -33,7 +31,7 @@ class RESTTraverse(DefaultPublishTraverse):
     def browserDefault(self, request):
         # Called when we have reached the end of the path
         # In our case this means an unamed service
-        return self.context, (NAME_PREFIX,)
+        return self.context, (request._rest_service_id,)
 
 
 class RESTWrapper(object):
@@ -74,7 +72,7 @@ class RESTWrapper(object):
         except (KeyError, AttributeError):
             # No object, maybe a named rest service
             service = queryMultiAdapter((self.context, request),
-                                        name=NAME_PREFIX + name)
+                                        name=request._rest_service_id + name)
             if service is None:
                 raise
             return service
@@ -85,4 +83,4 @@ class RESTWrapper(object):
     def browserDefault(self, request):
         # Called when we have reached the end of the path
         # In our case this means an unamed service
-        return self.context, (NAME_PREFIX,)
+        return self.context, (request._rest_service_id,)


### PR DESCRIPTION
Acceptable media types for content negotiation can be configured in ZCML with the service directive.

Constraint: Only Accept headers with a single media type are considered candidates for API requests. Browsers often send an Accept header with multiple media types including wildcards. Evaluating all media types would result in unwanted matches.

There's still some JSON specific code left, that should be removed or adapted to work with other media types. This affects the `Service` base class and the `ErrorHandling` view.

Fixes #32  