### PR TITLE
Add support for browser layers.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ Changelog
 1.0a4 (unreleased)
 ------------------
 
+- Add support for browser layers. REST services can now be registered to a
+  specific browser layer using the 'layer' attribute.
+  [buchi]
+
+- Remove request method specific marker interfaces (IGET, IPOST, etc.) because
+  they're  no longer required for service lookup.
+  [buchi]
+
 - Add support for content negotiation. REST services are no longer hardwired
   to 'application/json' Accept headers. Instead the media type can be
   configured with the service directive.

--- a/src/plone/rest/events.py
+++ b/src/plone/rest/events.py
@@ -1,11 +1,5 @@
 # -*- coding: utf-8 -*-
 from plone.rest.interfaces import IAPIRequest
-from plone.rest.interfaces import IDELETE
-from plone.rest.interfaces import IGET
-from plone.rest.interfaces import IOPTIONS
-from plone.rest.interfaces import IPATCH
-from plone.rest.interfaces import IPOST
-from plone.rest.interfaces import IPUT
 from plone.rest.negotiation import lookup_service_id
 from zope.interface import alsoProvides
 
@@ -22,19 +16,6 @@ def mark_as_api_request(event):
     if service_id is not None:
         alsoProvides(request, IAPIRequest)
         request._rest_service_id = service_id
-
-        if method == 'DELETE':
-            alsoProvides(request, IDELETE)
-        elif method == 'GET':
-            alsoProvides(request, IGET)
-        elif method == 'OPTIONS':
-            alsoProvides(request, IOPTIONS)
-        elif method == 'PATCH':
-            alsoProvides(request, IPATCH)
-        elif method == 'POST':
-            alsoProvides(request, IPOST)
-        elif method == 'PUT':
-            alsoProvides(request, IPUT)
 
         # Flag as non-WebDAV request in order to avoid special treatment
         # in ZPublisher.BaseRequest.traverse().

--- a/src/plone/rest/interfaces.py
+++ b/src/plone/rest/interfaces.py
@@ -2,36 +2,6 @@
 from zope.interface import Interface
 
 
-class IGET(Interface):
-    """ Get method
-    """
-
-
-class IPOST(Interface):
-    """ Post method
-    """
-
-
-class IPUT(Interface):
-    """ Put method
-    """
-
-
-class IDELETE(Interface):
-    """ Delete method
-    """
-
-
-class IOPTIONS(Interface):
-    """ Options method
-    """
-
-
-class IPATCH(Interface):
-    """ Patch method
-    """
-
-
 class IAPIRequest(Interface):
     """Marker for API requests.
     """

--- a/src/plone/rest/negotiation.py
+++ b/src/plone/rest/negotiation.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-NAME_PREFIX = u'rest'
-
 # Service registry
 # A mapping of method -> type name -> subtype name -> service id
 _services = {}
@@ -44,7 +42,7 @@ def register_service(method, media_type):
     """Register a service for the given request method and media type and
        return it's service id.
     """
-    service_id = u'{}_{}_{}'.format(NAME_PREFIX, media_type[0], media_type[1])
+    service_id = u'{}_{}_{}_'.format(method, media_type[0], media_type[1])
     types = _services.setdefault(method, {})
     subtypes = types.setdefault(media_type[0], {})
     subtypes[media_type[1]] = service_id

--- a/src/plone/rest/tests/test_negotiation.py
+++ b/src/plone/rest/tests/test_negotiation.py
@@ -53,19 +53,20 @@ class TestAcceptHeaderParser(unittest.TestCase):
 class TestServiceRegistry(unittest.TestCase):
 
     def test_register_media_type(self):
-        self.assertEqual('rest_application_json',
+        self.assertEqual(u'GET_application_json_',
                          register_service('GET', ('application', 'json')))
-        self.assertEqual('rest_application_json',
+        self.assertEqual(u'GET_application_json_',
                          lookup_service_id('GET', 'application/json'))
 
     def test_register_wildcard_subtype(self):
-        self.assertEqual('rest_text_*',
+        self.assertEqual(u'PATCH_text_*_',
                          register_service('PATCH', ('text', '*')))
-        self.assertEqual('rest_text_*', lookup_service_id('PATCH', 'text/xml'))
+        self.assertEqual(u'PATCH_text_*_',
+                         lookup_service_id('PATCH', 'text/xml'))
 
     def test_register_wilcard_type(self):
-        self.assertEqual('rest_*_*', register_service('PATCH', ('*', '*')))
-        self.assertEqual('rest_*_*', lookup_service_id('PATCH', 'foo/bar'))
+        self.assertEqual(u'PATCH_*_*_', register_service('PATCH', ('*', '*')))
+        self.assertEqual(u'PATCH_*_*_', lookup_service_id('PATCH', 'foo/bar'))
 
     def test_service_id_for_multiple_media_types_is_none(self):
         register_service('GET', 'application/json')


### PR DESCRIPTION
The request method is now part of the adapter name though there's no longer the need for request method specific marker interfaces. This allows us to use the second discriminator for browser layers.

Fixes #17 

/cc @tisto @bloodbare @lukasgraf @jone 