### PR TITLE
Restrict traversal of REST requests to content objects.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.0a5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Restrict traversal of REST requests to content objects. This allows us to
+  override existing views with a named service (e.g. /search).
+  [buchi]
 
 
 1.0a4 (2016-02-07)

--- a/src/plone/rest/interfaces.py
+++ b/src/plone/rest/interfaces.py
@@ -5,3 +5,8 @@ from zope.interface import Interface
 class IAPIRequest(Interface):
     """Marker for API requests.
     """
+
+
+class IService(Interface):
+    """Marker for REST services.
+    """

--- a/src/plone/rest/service.py
+++ b/src/plone/rest/service.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 from Products.Five import BrowserView
+from plone.rest.interfaces import IService
+from zope.interface import implements
 
 import json
 
 
 class Service(BrowserView):
+    implements(IService)
 
     def __call__(self):
         self.request.response.setHeader("Content-Type", "application/json")

--- a/src/plone/rest/testing.zcml
+++ b/src/plone/rest/testing.zcml
@@ -124,6 +124,13 @@
     name="namedservice"
     />
 
+  <plone:service
+    method="GET"
+    for="*"
+    factory=".demo.NamedGet"
+    name="search"
+    />
+
   <!-- Error Page -->
 
   <plone:service

--- a/src/plone/rest/tests/test_traversal.py
+++ b/src/plone/rest/tests/test_traversal.py
@@ -2,11 +2,13 @@
 from ZPublisher import BeforeTraverse
 from ZPublisher.pubevents import PubStart
 from base64 import b64encode
+from plone.app.layout.navigation.interfaces import INavigationRoot
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.rest.service import Service
 from plone.rest.testing import PLONE_REST_INTEGRATION_TESTING
 from zope.event import notify
+from zope.interface import alsoProvides
 
 import unittest
 
@@ -79,3 +81,21 @@ class TestTraversal(unittest.TestCase):
         obj = self.traverse(path='/plone/doc1')
         self.assertTrue(isinstance(obj, Service), 'Not a service')
         self.assertEquals(1, self.request._btr_test_called)
+
+    def test_json_request_on_existing_view_returns_named_service(self):
+        obj = self.traverse('/plone/search')
+        self.assertTrue(isinstance(obj, Service), 'Not a service')
+
+        folder = self.portal[self.portal.invokeFactory('Folder', id='folder1')]
+        alsoProvides(folder, INavigationRoot)
+        obj = self.traverse('/plone/folder1/search')
+        self.assertTrue(isinstance(obj, Service), 'Not a service')
+
+    def test_html_request_on_existing_view_returns_view(self):
+        obj = self.traverse(path='/plone/search', accept='text/html')
+        self.assertFalse(isinstance(obj, Service), 'Got a service')
+
+        folder = self.portal[self.portal.invokeFactory('Folder', id='folder1')]
+        alsoProvides(folder, INavigationRoot)
+        obj = self.traverse(path='/plone/folder1/search', accept='text/html')
+        self.assertFalse(isinstance(obj, Service), 'Got a service')

--- a/src/plone/rest/traverse.py
+++ b/src/plone/rest/traverse.py
@@ -2,10 +2,12 @@
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from ZPublisher.BaseRequest import DefaultPublishTraverse
 from plone.rest.interfaces import IAPIRequest
+from plone.rest.interfaces import IService
 from zope.component import adapts
 from zope.component import queryMultiAdapter
 from zope.interface import implements
 from zope.publisher.interfaces.browser import IBrowserPublisher
+from Products.CMFCore.interfaces import IContentish
 
 
 class RESTTraverse(DefaultPublishTraverse):
@@ -14,6 +16,9 @@ class RESTTraverse(DefaultPublishTraverse):
     def publishTraverse(self, request, name):
         try:
             obj = super(RESTTraverse, self).publishTraverse(request, name)
+            if (not IContentish.providedBy(obj)
+                    and not IService.providedBy(obj)):
+                raise KeyError
         except KeyError:
             # No object, maybe a named rest service
             service = queryMultiAdapter((self.context, request),
@@ -66,6 +71,9 @@ class RESTWrapper(object):
         adapter = DefaultPublishTraverse(self.context, request)
         try:
             obj = adapter.publishTraverse(request, name)
+            if (not IContentish.providedBy(obj)
+                    and not IService.providedBy(obj)):
+                raise KeyError
 
         # If there's no object with the given name, we get a KeyError.
         # In a non-folderish context a key lookup results in an AttributeError.


### PR DESCRIPTION
This allows us to override existing views with a named service (e.g. /search).

Fixes #42 