### PR TITLE
Improve message for 404 Not Found exceptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0a5 (unreleased)
 ------------------
 
+- Improve message for 404 Not Found exceptions (don't return HTML).
+  [lgraf]
+
 - Add regression tests for service dispatching.
   [lgraf]
 

--- a/src/plone/rest/errors.py
+++ b/src/plone/rest/errors.py
@@ -2,8 +2,10 @@ from AccessControl import getSecurityManager
 from plone.rest.interfaces import IAPIRequest
 from Products.CMFCore.permissions import ManagePortal
 from Products.Five.browser import BrowserView
+from zExceptions import NotFound
 from zope.component import adapter
 from zope.component.hooks import getSite
+
 import json
 import sys
 import traceback
@@ -33,6 +35,12 @@ class ErrorHandling(BrowserView):
     def render_exception(self, exception):
         result = {u'type': type(exception).__name__.decode('utf-8'),
                   u'message': str(exception).decode('utf-8')}
+
+        if isinstance(exception, NotFound):
+            # NotFound exceptions need special handling because their
+            # exception message gets turned into HTML by ZPublisher
+            url = self.request.getURL()
+            result[u'message'] = u'Resource not found: %s' % url
 
         if getSecurityManager().checkPermission(ManagePortal, getSite()):
             result[u'traceback'] = self.render_traceback(exception)

--- a/src/plone/rest/tests/test_error_handling.py
+++ b/src/plone/rest/tests/test_error_handling.py
@@ -48,6 +48,10 @@ class TestErrorHandling(unittest.TestCase):
             'NotFound',
             response.json()['type']
         )
+        self.assertEqual(
+            'Resource not found: %s' % response.url,
+            response.json()['message']
+        )
 
     def test_401_unauthorized(self):
         response = requests.get(


### PR DESCRIPTION
Because their exception message gets turned into HTML by ZPublisher, we set a custom message for them instead of just serializing the exception's string representation.

Before:
```
{
    "message": "  <h2>Site Error</h2>\n  <p>...</p>",
    "type": "NotFound"
}
```

After:

```
{
    "message": "Resource not found: http://localhost:8080/Plone/doesnt-exist",
    "type": "NotFound"
}
```

Fixes #22 