### PR TITLE
Implement permission handling.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ Changelog
 1.0a5 (unreleased)
 ------------------
 
+- Implement permission handling. The permission required to access a service
+  must be declared in the service directive.
+  [buchi]
+
+- Register services with the Zope configuration system. This provides better
+  conflict detection and resolution.
+  [buchi]
+
 - Improve message for 404 Not Found exceptions (don't return HTML).
   [lgraf]
 

--- a/README.rst
+++ b/README.rst
@@ -82,11 +82,13 @@ This is how you would register a PATCH request on Dexterity content:
     accept="application/json"
     for="plone.dexterity.interfaces.IDexterityContent"
     factory=".service.Patch"
+    permission="cmf.ModifyPortalContent"
     />
 
 You have to specify the HTTP verb (GET, POST, PUT, DELETE, HEAD, OPTIONS), the
-media type used for content negotiation, the interface for the content objects
-and the factory class that actually returns the content.
+media type used for content negotiation, the interface for the content objects,
+the factory class that actually returns the content and the permission required
+to access the service.
 
 The factory class needs to inherit from the plone.rest 'Service' class and to implement a render method that returns a list or a dict::
 
@@ -167,6 +169,7 @@ Named services can be registered by providing a 'name' attribute in the service 
     for="Products.CMFPlone.interfaces.IPloneSiteRoot"
     factory=".service.Search"
     name="search"
+    permission="zope2.View"
     />
 
 This registers a service endpoint accessible at the site root using the

--- a/src/plone/rest/service.py
+++ b/src/plone/rest/service.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
-from Products.Five import BrowserView
 from plone.rest.interfaces import IService
 from zope.interface import implements
 
 import json
 
 
-class Service(BrowserView):
+class Service(object):
     implements(IService)
 
     def __call__(self):

--- a/src/plone/rest/testing.zcml
+++ b/src/plone/rest/testing.zcml
@@ -10,36 +10,42 @@
     method="GET"
     for="plone.dexterity.interfaces.IDexterityContent"
     factory=".demo.Get"
+    permission="zope2.View"
     />
 
   <plone:service
     method="POST"
     for="plone.dexterity.interfaces.IDexterityContent"
     factory=".demo.Post"
+    permission="cmf.AddPortalContent"
     />
 
   <plone:service
     method="PUT"
     for="plone.dexterity.interfaces.IDexterityContent"
     factory=".demo.Put"
+    permission="cmf.ModifyPortalContent"
     />
 
   <plone:service
     method="DELETE"
     for="plone.dexterity.interfaces.IDexterityContent"
     factory=".demo.Delete"
+    permission="zope2.DeleteObjects"
     />
 
   <plone:service
     method="PATCH"
     for="plone.dexterity.interfaces.IDexterityContent"
     factory=".demo.Patch"
+    permission="cmf.ModifyPortalContent"
     />
 
   <plone:service
     method="OPTIONS"
     for="plone.dexterity.interfaces.IDexterityContent"
     factory=".demo.Options"
+    permission="zope2.View"
     />
 
   <!-- Plone Site Root -->
@@ -48,36 +54,42 @@
     method="GET"
     for="Products.CMFPlone.interfaces.IPloneSiteRoot"
     factory=".demo.Get"
+    permission="zope2.View"
     />
 
   <plone:service
     method="POST"
     for="Products.CMFPlone.interfaces.IPloneSiteRoot"
     factory=".demo.Post"
+    permission="cmf.AddPortalContent"
     />
 
   <plone:service
     method="PUT"
     for="Products.CMFPlone.interfaces.IPloneSiteRoot"
     factory=".demo.Put"
+    permission="cmf.ModifyPortalContent"
     />
 
   <plone:service
     method="DELETE"
     for="Products.CMFPlone.interfaces.IPloneSiteRoot"
     factory=".demo.Delete"
+    permission="zope2.DeleteObjects"
     />
 
   <plone:service
     method="PATCH"
     for="Products.CMFPlone.interfaces.IPloneSiteRoot"
     factory=".demo.Patch"
+    permission="cmf.ModifyPortalContent"
     />
 
   <plone:service
     method="OPTIONS"
     for="Products.CMFPlone.interfaces.IPloneSiteRoot"
     factory=".demo.Options"
+    permission="zope2.View"
     />
 
   <!-- Dexterity named services -->
@@ -86,6 +98,7 @@
     method="GET"
     for="plone.dexterity.interfaces.IDexterityContent"
     factory=".demo.NamedGet"
+    permission="zope2.View"
     name="namedservice"
     />
 
@@ -94,6 +107,7 @@
     for="plone.dexterity.interfaces.IDexterityContent"
     factory=".demo.NamedPost"
     name="namedservice"
+    permission="cmf.AddPortalContent"
     />
 
   <plone:service
@@ -101,6 +115,7 @@
     for="plone.dexterity.interfaces.IDexterityContent"
     factory=".demo.NamedPut"
     name="namedservice"
+    permission="cmf.ModifyPortalContent"
     />
 
   <plone:service
@@ -108,6 +123,7 @@
     for="plone.dexterity.interfaces.IDexterityContent"
     factory=".demo.NamedDelete"
     name="namedservice"
+    permission="zope2.DeleteObjects"
     />
 
   <plone:service
@@ -115,6 +131,7 @@
     for="plone.dexterity.interfaces.IDexterityContent"
     factory=".demo.NamedPatch"
     name="namedservice"
+    permission="cmf.ModifyPortalContent"
     />
 
   <plone:service
@@ -122,6 +139,7 @@
     for="plone.dexterity.interfaces.IDexterityContent"
     factory=".demo.NamedOptions"
     name="namedservice"
+    permission="zope2.View"
     />
 
   <plone:service
@@ -129,6 +147,7 @@
     for="*"
     factory=".demo.NamedGet"
     name="search"
+    permission="zope2.View"
     />
 
   <!-- Error Page -->
@@ -138,6 +157,7 @@
     for="*"
     name="500-internal-server-error"
     factory=".testing.InternalServerErrorService"
+    permission="zope2.View"
     />
 
 </configure>

--- a/src/plone/rest/tests/test_dispatching.py
+++ b/src/plone/rest/tests/test_dispatching.py
@@ -70,10 +70,10 @@ class TestDispatchingSiteRoot(DispatchingTestCase):
     def test_site_root_without_creds(self):
         expectations = [
             ('/', 'GET', NO_CREDS, 200),
-            ('/', 'POST', NO_CREDS, 200),
-            ('/', 'PUT', NO_CREDS, 200),
-            ('/', 'PATCH', NO_CREDS, 200),
-            ('/', 'DELETE', NO_CREDS, 200),
+            ('/', 'POST', NO_CREDS, 401),
+            ('/', 'PUT', NO_CREDS, 401),
+            ('/', 'PATCH', NO_CREDS, 401),
+            ('/', 'DELETE', NO_CREDS, 401),
             ('/', 'OPTIONS', NO_CREDS, 200),
         ]
         self.validate(expectations)
@@ -81,10 +81,10 @@ class TestDispatchingSiteRoot(DispatchingTestCase):
     def test_site_root_invalid_creds(self):
         expectations = [
             ('/', 'GET', INVALID_CREDS, 200),
-            ('/', 'POST', INVALID_CREDS, 200),
-            ('/', 'PUT', INVALID_CREDS, 200),
-            ('/', 'PATCH', INVALID_CREDS, 200),
-            ('/', 'DELETE', INVALID_CREDS, 200),
+            ('/', 'POST', INVALID_CREDS, 401),
+            ('/', 'PUT', INVALID_CREDS, 401),
+            ('/', 'PATCH', INVALID_CREDS, 401),
+            ('/', 'DELETE', INVALID_CREDS, 401),
             ('/', 'OPTIONS', INVALID_CREDS, 200),
         ]
         self.validate(expectations)
@@ -186,10 +186,10 @@ class TestDispatchingDexterity(DispatchingTestCase):
     def test_public_dx_folder_without_creds(self):
         expectations = [
             ('/public', 'GET', NO_CREDS, 200),
-            ('/public', 'POST', NO_CREDS, 200),
-            ('/public', 'PUT', NO_CREDS, 200),
-            ('/public', 'PATCH', NO_CREDS, 200),
-            ('/public', 'DELETE', NO_CREDS, 200),
+            ('/public', 'POST', NO_CREDS, 401),
+            ('/public', 'PUT', NO_CREDS, 401),
+            ('/public', 'PATCH', NO_CREDS, 401),
+            ('/public', 'DELETE', NO_CREDS, 401),
             ('/public', 'OPTIONS', NO_CREDS, 200),
         ]
         self.validate(expectations)
@@ -197,10 +197,10 @@ class TestDispatchingDexterity(DispatchingTestCase):
     def test_public_dx_folder_invalid_creds(self):
         expectations = [
             ('/public', 'GET', INVALID_CREDS, 200),
-            ('/public', 'POST', INVALID_CREDS, 200),
-            ('/public', 'PUT', INVALID_CREDS, 200),
-            ('/public', 'PATCH', INVALID_CREDS, 200),
-            ('/public', 'DELETE', INVALID_CREDS, 200),
+            ('/public', 'POST', INVALID_CREDS, 401),
+            ('/public', 'PUT', INVALID_CREDS, 401),
+            ('/public', 'PATCH', INVALID_CREDS, 401),
+            ('/public', 'DELETE', INVALID_CREDS, 401),
             ('/public', 'OPTIONS', INVALID_CREDS, 200),
         ]
         self.validate(expectations)

--- a/src/plone/rest/tests/test_permissions.py
+++ b/src/plone/rest/tests/test_permissions.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from Products.CMFCore.utils import getToolByName
+from ZPublisher.pubevents import PubStart
+from base64 import b64encode
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import TEST_USER_PASSWORD
+from plone.app.testing import login
+from plone.app.testing import setRoles
+from plone.rest.service import Service
+from plone.rest.testing import PLONE_REST_INTEGRATION_TESTING
+from zExceptions import Unauthorized
+from zope.event import notify
+
+import unittest
+
+
+class TestPermissions(unittest.TestCase):
+
+    layer = PLONE_REST_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+        setRoles(self.portal, TEST_USER_ID, ['Member'])
+        login(self.portal, SITE_OWNER_NAME)
+        self.portal.invokeFactory('Document', id='doc1')
+        wftool = getToolByName(self.portal, 'portal_workflow')
+        wftool.doActionFor(self.portal.doc1, 'publish')
+
+    def traverse(self, path='/plone', accept='application/json', method='GET'):
+        request = self.layer['request']
+        request.environ['PATH_INFO'] = path
+        request.environ['PATH_TRANSLATED'] = path
+        request.environ['HTTP_ACCEPT'] = accept
+        request.environ['REQUEST_METHOD'] = method
+        request._auth = 'Basic %s' % b64encode(
+            '%s:%s' % (TEST_USER_NAME, TEST_USER_PASSWORD))
+        notify(PubStart(request))
+        return request.traverse(path)
+
+    def test_traverse_with_insufficient_permission_raises_unauthorized(self):
+        setRoles(self.portal, TEST_USER_ID, ['Member'])
+        with self.assertRaises(Unauthorized):
+            self.traverse('/plone/doc1', method='PUT')
+
+    def test_traverse_with_sufficient_permission_returns_service(self):
+        setRoles(self.portal, TEST_USER_ID, ['Editor'])
+        obj = self.traverse('/plone/doc1', method='PUT')
+        self.assertTrue(isinstance(obj, Service), 'Not a service')


### PR DESCRIPTION
Register services with the Zope configuration system instead of just registering an adapter. This provides better conflict detection and resolution.

Permission handling:
Currently the `permission` attribute is optional. This means that by default a service doesn't have a security declaration making it accessible for users that can access the underlying content object.

IMO we should make the `permission`attribute mandatory. However this will break current service definitions that don't already declare a permission. But as this concerns security, I think it's better if the user needs to declare a permission explicitly (same behavior as with browser views).
Opinions?

Fixes #36 