### PR TITLE
Remove json rendering

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Changelog
 - Add support for CORS policies.
   [buchi]
 
+- Remove JSON render implementation in service base class. Services
+  must provide their own render implementation.
+  [buchi]
+
 
 1.0a5 (2016-02-27)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -90,17 +90,14 @@ media type used for content negotiation, the interface for the content objects,
 the factory class that actually returns the content and the permission required
 to access the service.
 
-The factory class needs to inherit from the plone.rest 'Service' class and to implement a render method that returns a list or a dict::
+The factory class needs to inherit from the plone.rest 'Service' class and to implement a render method that returns the body of the response::
 
   from plone.rest import Service
 
   class Patch(Service):
 
       def render(self):
-          return {'message': 'PATCH: Hello World!'}
-
-
-The return value (list or dict) will be automatically transformed into JSON.
+          return '{"message": "PATCH: Hello World!"}'
 
 
 Content Negotiation
@@ -118,7 +115,7 @@ The server then will respond with '200 OK'::
   Content-Type: application/json
 
   {
-    'message': 'PATCH: Hello World!'
+    "message": "PATCH: Hello World!"
   }
 
 You can try this out on the command line:

--- a/src/plone/rest/demo.py
+++ b/src/plone/rest/demo.py
@@ -1,92 +1,101 @@
 # -*- coding: utf-8 -*-
 from plone.rest import Service
 
+import json
 
-class Get(Service):
+
+class BaseService(Service):
 
     def render(self):
+        self.request.response.setHeader("Content-Type", "application/json")
+        return json.dumps(self.data(), indent=2, sort_keys=True)
+
+
+class Get(BaseService):
+
+    def data(self):
         return {
             'method': 'GET',
             'id': self.context.id
         }
 
 
-class Post(Service):
+class Post(BaseService):
 
-    def render(self):
+    def data(self):
         return {
             'method': 'POST',
             'id': self.context.id
         }
 
 
-class Put(Service):
+class Put(BaseService):
 
-    def render(self):
+    def data(self):
         return {
             'method': 'PUT',
             'id': self.context.id
         }
 
 
-class Delete(Service):
+class Delete(BaseService):
 
-    def render(self):
+    def data(self):
         return {
             'method': 'DELETE',
             'id': self.context.id
         }
 
 
-class Patch(Service):
+class Patch(BaseService):
 
-    def render(self):
+    def data(self):
         return {
             'method': 'PATCH',
             'id': self.context.id
         }
 
 
-class Options(Service):
+class Options(BaseService):
 
-    def render(self):
+    def data(self):
         return {
             'method': 'OPTIONS',
             'id': self.context.id
         }
 
 
-class NamedGet(Service):
+class NamedGet(BaseService):
 
-    def render(self):
+    def data(self):
         return {'service': 'named get'}
 
 
-class NamedPost(Service):
+class NamedPost(BaseService):
 
-    def render(self):
+    def data(self):
         return {'service': 'named post'}
 
 
-class NamedPut(Service):
+class NamedPut(BaseService):
 
-    def render(self):
+    def data(self):
         return {'service': 'named put'}
 
 
-class NamedDelete(Service):
+class NamedDelete(BaseService):
 
-    def render(self):
+    def data(self):
         return {'service': 'named delete'}
 
 
-class NamedPatch(Service):
+class NamedPatch(BaseService):
 
-    def render(self):
+    def data(self):
         return {'service': 'named patch'}
 
 
-class NamedOptions(Service):
+class NamedOptions(BaseService):
 
-    def render(self):
+    def data(self):
         return {'service': 'named options'}

--- a/src/plone/rest/service.py
+++ b/src/plone/rest/service.py
@@ -4,8 +4,6 @@ from plone.rest.interfaces import IService
 from zope.component import queryMultiAdapter
 from zope.interface import implements
 
-import json
-
 
 class Service(object):
     implements(IService)
@@ -19,8 +17,10 @@ class Service(object):
             else:
                 policy.process_simple_request()
 
-        self.request.response.setHeader("Content-Type", "application/json")
-        return json.dumps(self.render(), indent=2, sort_keys=True)
+        return self.render()
+
+    def render(self):
+        raise NotImplementedError
 
     def __getattribute__(self, name):
         # Preflight requests need to be publicly accessible since they don't


### PR DESCRIPTION
As plone.rest supports arbitrary content types now, it no longer makes sense to render JSON in plone.rest.

We are moving this functionality into plone.restapi.

Fixes #46 