### PR TITLE
Fallback to regular views during traversal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ Changelog
   must provide their own render implementation.
   [buchi]
 
+- Fallback to regular views during traversal to ensure compatibility with
+  views beeing called with a specific Accept header.
+  [buchi]
+
 
 1.0a5 (2016-02-27)
 ------------------

--- a/src/plone/rest/tests/test_traversal.py
+++ b/src/plone/rest/tests/test_traversal.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from Products.SiteAccess.VirtualHostMonster import VirtualHostMonster
 from ZPublisher import BeforeTraverse
 from ZPublisher.pubevents import PubStart
 from base64 import b64encode
@@ -7,9 +8,9 @@ from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.rest.service import Service
 from plone.rest.testing import PLONE_REST_INTEGRATION_TESTING
-from Products.SiteAccess.VirtualHostMonster import VirtualHostMonster
 from zope.event import notify
 from zope.interface import alsoProvides
+from zope.publisher.interfaces.browser import IBrowserView
 
 import unittest
 
@@ -109,3 +110,11 @@ class TestTraversal(unittest.TestCase):
         obj = self.traverse(path='/VirtualHostBase/http/localhost:8080/plone/VirtualHostRoot/')  # noqa
         self.assertTrue(isinstance(obj, Service), 'Not a service')
         del app['virtual_hosting']
+
+    def test_json_request_to_regular_view_returns_view(self):
+        obj = self.traverse('/plone/folder_contents')
+        self.assertTrue(IBrowserView.providedBy(obj), 'IBrowserView expected')
+
+        self.portal[self.portal.invokeFactory('Folder', id='folder1')]
+        obj = self.traverse('/plone/folder1/folder_contents')
+        self.assertTrue(IBrowserView.providedBy(obj), 'IBrowserView expected')

--- a/src/plone/rest/traverse.py
+++ b/src/plone/rest/traverse.py
@@ -28,6 +28,10 @@ class RESTTraverse(DefaultPublishTraverse):
             service = queryMultiAdapter((self.context, request),
                                         name=request._rest_service_id + name)
             if service is None:
+                # No service, fallback to regular view
+                view = queryMultiAdapter((self.context, request), name=name)
+                if view is not None:
+                    return view
                 raise
             return service
 
@@ -86,6 +90,10 @@ class RESTWrapper(object):
             service = queryMultiAdapter((self.context, request),
                                         name=request._rest_service_id + name)
             if service is None:
+                # No service, fallback to regular view
+                view = queryMultiAdapter((self.context, request), name=name)
+                if view is not None:
+                    return view
                 raise
             return service
         else:


### PR DESCRIPTION
This ensures compatiblity with existing views that are beeing called with a
specific Accept header.

Fixes #50 