### PR TITLE
extract IPloneSiteRoot in favor of ISiteRoot

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,17 +4,9 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-Breaking changes:
-
-- *add item here*
-
 New features:
 
-- *add item here*
-
-Bug fixes:
-
-- *add item here*
+- Extract IPloneSiteRoot in favor of ISiteRoot from CMFCore
 
 
 1.2.0 (2018-06-29)

--- a/src/plone/rest/traverse.py
+++ b/src/plone/rest/traverse.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from Products.SiteAccess.VirtualHostMonster import VirtualHostMonster
 from ZPublisher.BaseRequest import DefaultPublishTraverse
 from plone.rest.interfaces import IAPIRequest
@@ -9,10 +8,11 @@ from zope.component import queryMultiAdapter
 from zope.interface import implements
 from zope.publisher.interfaces.browser import IBrowserPublisher
 from Products.CMFCore.interfaces import IContentish
+from Products.CMFCore.interfaces import ISiteRoot
 
 
 class RESTTraverse(DefaultPublishTraverse):
-    adapts(IPloneSiteRoot, IAPIRequest)
+    adapts(ISiteRoot, IAPIRequest)
 
     def publishTraverse(self, request, name):
         try:


### PR DESCRIPTION
This way the package could be used on a zope installation
without the plone core