### PR TITLE
Explicitly make allow_credentials required in CORS policy.

### DIFF
--- a/news/104.bugfix
+++ b/news/104.bugfix
@@ -1,0 +1,3 @@
+Explicitly make ``allow_credentials`` required in CORS policy.
+This was the default for Bool fields until and including zope.schema 6.0.1, but in 6.1.0 this changed.
+[maurits]

--- a/src/plone/rest/zcml.py
+++ b/src/plone/rest/zcml.py
@@ -186,6 +186,7 @@ class ICORSPolicyDirective(Interface):
         title=u"Support Credentials",
         description=u"""Indicates whether the resource supports user
         credentials in the request.""",
+        required=True,
         default=False,
     )
 


### PR DESCRIPTION
This was the default for Bool fields until and including zope.schema 6.0.1.
In 6.1.0 this changed.
Since we have a default in the field definition, it does not look like any changes are needed for people using `plone.rest`.

Without this, we get errors like this on Jenkins with Plone coredev 6:

```
$ bin/test -s plone.rest
...
  File "/Users/maurits/shared-eggs/cp38/zope.configuration-4.4.0-py3.8.egg
/zope/configuration/config.py", line 869, in finish
    actions = self.handler(context, **args)
zope.configuration.xmlconfig.ZopeXMLConfigurationError:
File "/Users/maurits/community/plone-coredev/6.0/src/plone.rest/src/plone/rest/testing.zcml", line 163.2-167.6
    TypeError: cors_policy_directive() missing 1 required positional argument: 'allow_credentials'
```

See https://github.com/zopefoundation/zope.schema/issues/104#issuecomment-776747141