### PR TITLE
test(deprecation): Fix all warnings from our code

### DIFF
--- a/news/128.bugfix
+++ b/news/128.bugfix
@@ -1,0 +1,3 @@
+Resolve all the deprecation warnings that originate in this package's code that are
+exposed by running the tests that do not stem from backwards compatibility we support.
+[rpatterson]

--- a/src/plone/rest/tests/test_redirects.py
+++ b/src/plone/rest/tests/test_redirects.py
@@ -176,4 +176,4 @@ class TestRedirects(unittest.TestCase):
     def test_gracefully_deals_with_missing_request_url(self):
         error_view = ErrorHandling(self.portal, self.portal.REQUEST)
         self.portal.REQUEST["ACTUAL_URL"] = None
-        self.assertEquals(False, error_view.attempt_redirect())
+        self.assertEqual(False, error_view.attempt_redirect())

--- a/src/plone/rest/tests/test_traversal.py
+++ b/src/plone/rest/tests/test_traversal.py
@@ -60,18 +60,18 @@ class TestTraversal(unittest.TestCase):
 
     def test_html_request_on_portal_root_returns_default_view(self):
         obj = self.traverse(accept="text/html")
-        self.assertEquals(self.portal.getDefaultLayout(), obj.__name__)
+        self.assertEqual(self.portal.getDefaultLayout(), obj.__name__)
 
     def test_html_request_on_portal_root_returns_dynamic_view(self):
         self.portal.setLayout("summary_view")
         obj = self.traverse(accept="text/html")
-        self.assertEquals("summary_view", obj.__name__)
+        self.assertEqual("summary_view", obj.__name__)
 
     def test_html_request_on_portal_root_returns_default_page(self):
         self.portal.invokeFactory("Document", id="doc1")
         self.portal.setDefaultPage("doc1")
         obj = self.traverse(accept="text/html")
-        self.assertEquals("document_view", obj.__name__)
+        self.assertEqual("document_view", obj.__name__)
 
     def test_json_request_on_object_with_multihook(self):
         doc1 = self.portal[self.portal.invokeFactory("Document", id="doc1")]
@@ -86,7 +86,7 @@ class TestTraversal(unittest.TestCase):
 
         obj = self.traverse(path="/plone/doc1")
         self.assertTrue(isinstance(obj, Service), "Not a service")
-        self.assertEquals(1, self.request._btr_test_called)
+        self.assertEqual(1, self.request._btr_test_called)
 
     def test_json_request_on_existing_view_returns_named_service(self):
         obj = self.traverse("/plone/search")


### PR DESCRIPTION
Resolve all the deprecation warnings that originate in this package's code that are
exposed by running the tests.