### PR TITLE
++api++ traverser should be kept on 30x redirections

### DIFF
--- a/news/127.fix
+++ b/news/127.fix
@@ -1,0 +1,1 @@
+++api++ traverser should be kept on 30x redirections [mamico]

--- a/src/plone/rest/errors.py
+++ b/src/plone/rest/errors.py
@@ -169,6 +169,9 @@ class ErrorHandling(BrowserView):
         if not url:
             return False
 
+        # remove ++api++ traverser to make `physicalPathFromURL` do the right job
+        url = url.replace("/++api++", "")
+
         try:
             old_path_elements = self.request.physicalPathFromURL(url)
         except ValueError:  # pragma: no cover

--- a/src/plone/rest/tests/test_redirects.py
+++ b/src/plone/rest/tests/test_redirects.py
@@ -39,6 +39,16 @@ class TestRedirects(unittest.TestCase):
         self.assertEqual(self.portal_url + "/folder-new", response.headers["Location"])
         self.assertEqual(b"", response.raw.read())
 
+    def test_get_to_moved_item_causes_301_redirect_with_api_traverser(self):
+        response = requests.get(
+            self.portal_url + "/++api++/folder-old",
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+            allow_redirects=False,
+        )
+        self.assertEqual(301, response.status_code)
+        self.assertEqual(self.portal_url + "/folder-new", response.headers["Location"])
+        self.assertEqual(b"", response.raw.read())
+
     def test_post_to_moved_item_causes_308_redirect(self):
         response = requests.post(
             self.portal_url + "/folder-old",


### PR DESCRIPTION
Fix #127 