### PR TITLE
redirect with view

### DIFF
--- a/news/132.fix
+++ b/news/132.fix
@@ -1,0 +1,1 @@
+++api++ traverser should be kept on 30x redirections [mamico]

--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -1,11 +1,12 @@
 [buildout]
 extends =
     base.cfg
-    https://dist.plone.org/release/5.2.4/versions.cfg
+    https://dist.plone.org/release/5.2.7/versions.cfg
 find-links += https://dist.plone.org/thirdparty/
 versions=versions
 
 [versions]
+plone.rest =
 black = 21.12b0
 
 # Error: The requirement ('virtualenv>=20.0.35') is not allowed by your [versions] constraint (20.0.26)

--- a/src/plone/rest/errors.py
+++ b/src/plone/rest/errors.py
@@ -180,7 +180,12 @@ class ErrorHandling(BrowserView):
             return False
 
         # remove ++api++ traverser
-        old_path = "/".join(filter("++api++".__ne__, old_path_elements))
+        if "++api++" in old_path_elements:
+            api_traverser_pos = old_path_elements.index("++api++")
+            old_path_elements = [el for el in old_path_elements if el != "++api++"]
+        else:
+            api_traverser_pos = None
+        old_path = "/".join(old_path_elements)
 
         # First lets try with query string in cases or content migration
 
@@ -214,9 +219,9 @@ class ErrorHandling(BrowserView):
             url = urllib.parse.SplitResult(*(url[:2] + (url_path,) + url[3:])).geturl()
         else:
             # reinsert ++api++ traverser
-            if "++api++" in old_path_elements:
+            if api_traverser_pos is not None:
                 new_path_elements = new_path.split("/")
-                new_path_elements.insert(old_path_elements.index("++api++"), "++api++")
+                new_path_elements.insert(api_traverser_pos, "++api++")
                 new_path = "/".join(new_path_elements)
             url = self.request.physicalPathToURL(new_path)
 

--- a/src/plone/rest/tests/test_redirects.py
+++ b/src/plone/rest/tests/test_redirects.py
@@ -67,7 +67,8 @@ class TestRedirects(unittest.TestCase):
         )
         self.assertEqual(301, response.status_code)
         self.assertEqual(
-            self.portal_url + "/++api++/folder-new/@actions", response.headers["Location"]
+            self.portal_url + "/++api++/folder-new/@actions",
+            response.headers["Location"]
         )
         self.assertEqual(b"", response.raw.read())
 

--- a/src/plone/rest/tests/test_redirects.py
+++ b/src/plone/rest/tests/test_redirects.py
@@ -68,7 +68,7 @@ class TestRedirects(unittest.TestCase):
         self.assertEqual(301, response.status_code)
         self.assertEqual(
             self.portal_url + "/++api++/folder-new/@actions",
-            response.headers["Location"]
+            response.headers["Location"],
         )
         self.assertEqual(b"", response.raw.read())
 

--- a/src/plone/rest/tests/test_redirects.py
+++ b/src/plone/rest/tests/test_redirects.py
@@ -59,6 +59,18 @@ class TestRedirects(unittest.TestCase):
         self.assertEqual("application/json", response.headers["Content-type"])
         self.assertEqual({"id": "folder-new", "method": "GET"}, response.json())
 
+    def test_get_to_moved_item_causes_301_redirect_with_rest_view(self):
+        response = requests.get(
+            self.portal_url + "/++api++/folder-old/@actions",
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+            allow_redirects=False,
+        )
+        self.assertEqual(301, response.status_code)
+        self.assertEqual(
+            self.portal_url + "/++api++/folder-new/@actions", response.headers["Location"]
+        )
+        self.assertEqual(b"", response.raw.read())
+
     def test_post_to_moved_item_causes_308_redirect(self):
         response = requests.post(
             self.portal_url + "/folder-old",


### PR DESCRIPTION
This is a #130 follow-up.

The previous pull request fixes the redirect for content, but doesn't work for views (my fault, sorry). 

p.s I'm opening another PR about changing from 301 to safer 302 redirects, as in p.a.redirector (refs. https://github.com/plone/plone.app.redirector/issues/8 https://github.com/plone/plone.app.redirector/issues/22) 


