### PR TITLE
Fixup tests: reset SKIP_PTA to whatever it was

### DIFF
--- a/news/168.bugfix
+++ b/news/168.bugfix
@@ -1,0 +1,1 @@
+Fix test leakage, enabling the publication check when it shouldn't be active. @jaroel

--- a/news/168.bugfix
+++ b/news/168.bugfix
@@ -1,1 +1,0 @@
-Fix test leakage, enabling the publication check when it shouldn't be active. @jaroel

--- a/news/168.internal
+++ b/news/168.internal
@@ -1,0 +1,1 @@
+Fix test leakage, enabling the publication check when it shouldn't be active. @jaroel

--- a/src/plone/rest/tests/test_explicitacquisition.py
+++ b/src/plone/rest/tests/test_explicitacquisition.py
@@ -68,10 +68,18 @@ class TestExplicitAcquisitionAvailable(unittest.TestCase):
     layer = PLONE_REST_INTEGRATION_TESTING
 
     def setUp(self):
+        import Products.CMFCore.explicitacquisition
+
         self.portal = self.layer["portal"]
         self.request = self.layer["request"]
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
         self.portal.invokeFactory("Document", id="foo")
+        self.PREVIOUS_SKIP_PTA = Products.CMFCore.explicitacquisition.SKIP_PTA
+
+    def tearDown(self):
+        import Products.CMFCore.explicitacquisition
+
+        Products.CMFCore.explicitacquisition.SKIP_PTA = self.PREVIOUS_SKIP_PTA
 
     def traverse(self, path="/plone", accept="application/json", method="GET"):
         request = self.layer["request"]


### PR DESCRIPTION
Before it would leak into other tests, enabling the publication check when it shouldn't be active.