### PR TITLE
Uses Python 3.12.0 in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,10 +6,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.11", "3.10", "3.9", "3.8"]
+        # FIXME: Change to 3.12 when errors in tests with Python 3.12.1 are fixed.
+        python-version: ["3.12.0", "3.11", "3.10", "3.9", "3.8"]
         plone-version: ["6.0", "5.2"]
         exclude:
-          - python-version: 3.12
+          - python-version: 3.12.0
             plone-version: 5.2
           - python-version: 3.11
             plone-version: 5.2

--- a/base.cfg
+++ b/base.cfg
@@ -8,6 +8,7 @@ parts =
     test-coverage
     code-analysis
     releaser
+    omelette
 develop = .
 sources-dir = extras
 auto-checkout =
@@ -58,6 +59,10 @@ eggs =
     towncrier
     readme
     docutils
+
+[omelette]
+recipe = collective.recipe.omelette
+eggs = ${test:eggs}
 
 [sources]
 plone.dexterity = git git://github.com/plone/plone.dexterity.git pushurl=git@github.com:plone/plone.dexterity.git branch=plip-680

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,3 +1,3 @@
 [buildout]
-extends = plone-5.2.x.cfg
+extends = plone-6.0.x.cfg
 

--- a/news/175.internal
+++ b/news/175.internal
@@ -1,0 +1,1 @@
+Uses Python 3.12.0 in tests, while https://github.com/zopefoundation/Zope/issues/1188 is not fixed. @wesleybl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
-# Keep this file in sync with: https://github.com/kitconcept/buildout/edit/master/requirements.txt
-setuptools==42.0.2
-zc.buildout==2.13.4
-wheel
+-r requirements-6.0.txt


### PR DESCRIPTION
Uses Python 3.12.0 in tests, while errors in tests with Python 3.12.1 are not fixed.

Tests in 3.12.1 is broken.