### PR TITLE
Returns "message" as an object instead of a string, when a BadRequest occurs

### DIFF
--- a/news/176.feature
+++ b/news/176.feature
@@ -1,0 +1,1 @@
+Returns ``message`` as an object instead of a string, when a ``BadRequest`` occurs. This makes it possible for the error message to reach the client as an object, avoiding the need for string-to-object conversions. @wesleybl

--- a/src/plone/rest/errors.py
+++ b/src/plone/rest/errors.py
@@ -6,6 +6,7 @@ from Products.CMFCore.permissions import ManagePortal
 from Products.Five.browser import BrowserView
 from urllib.parse import quote
 from urllib.parse import unquote
+from zExceptions import BadRequest
 from zExceptions import NotFound
 from zope.component import adapter
 from zope.component import queryMultiAdapter
@@ -57,7 +58,10 @@ class ErrorHandling(BrowserView):
 
     def render_exception(self, exception):
         name = type(exception).__name__
-        message = str(exception)
+        if isinstance(exception, BadRequest):
+            message = exception.args[0]
+        else:
+            message = str(exception)
         result = {"type": name, "message": message}
 
         policy = queryMultiAdapter((self.context, self.request), ICORSPolicy)

--- a/src/plone/rest/testing.py
+++ b/src/plone/rest/testing.py
@@ -37,3 +37,12 @@ class InternalServerErrorService(Service):
             {},
             None,
         )
+
+
+class BadRequestService(Service):
+    def __call__(self):
+        from zExceptions import BadRequest
+
+        errors = [{"error": "ValidationError", "message": "message error"}]
+
+        raise BadRequest(errors)

--- a/src/plone/rest/testing.py
+++ b/src/plone/rest/testing.py
@@ -46,3 +46,12 @@ class BadRequestService(Service):
         errors = [{"error": "ValidationError", "message": "message error"}]
 
         raise BadRequest(errors)
+
+
+class BadRequestNoSerializableService(Service):
+    def __call__(self):
+        from zExceptions import BadRequest
+
+        errors = [{"error": Exception("error"), "message": "message error"}]
+
+        raise BadRequest(errors)

--- a/src/plone/rest/testing.zcml
+++ b/src/plone/rest/testing.zcml
@@ -167,4 +167,12 @@
       expose_headers="X-My-Header"
       />
 
+  <plone:service
+      method="GET"
+      factory=".testing.BadRequestService"
+      for="*"
+      permission="zope2.View"
+      name="bad-request-error"
+      />
+
 </configure>

--- a/src/plone/rest/testing.zcml
+++ b/src/plone/rest/testing.zcml
@@ -175,4 +175,12 @@
       name="bad-request-error"
       />
 
+  <plone:service
+      method="GET"
+      factory=".testing.BadRequestNoSerializableService"
+      for="*"
+      permission="zope2.View"
+      name="bad-request-no-serializable"
+      />
+
 </configure>

--- a/src/plone/rest/tests/test_error_handling.py
+++ b/src/plone/rest/tests/test_error_handling.py
@@ -118,3 +118,14 @@ class TestErrorHandling(unittest.TestCase):
             response.json()["message"],
             [{"error": "ValidationError", "message": "message error"}],
         )
+
+    def test_bad_request_no_serializable_message(self):
+        response = requests.get(
+            f"{self.portal_url}/bad-request-no-serializable",
+            headers={"Accept": "application/json"},
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+        )
+        self.assertEqual(
+            response.json()["message"],
+            [{"error": "Exception('error')", "message": "message error"}],
+        )

--- a/src/plone/rest/tests/test_error_handling.py
+++ b/src/plone/rest/tests/test_error_handling.py
@@ -107,3 +107,14 @@ class TestErrorHandling(unittest.TestCase):
         self.assertRegex(
             traceback[0], r'^File "[^"]*", line \d*, in (publish|transaction_pubevents)'
         )
+
+    def test_bad_request_error_message(self):
+        response = requests.get(
+            f"{self.portal_url}/bad-request-error",
+            headers={"Accept": "application/json"},
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+        )
+        self.assertEqual(
+            response.json()["message"],
+            [{"error": "ValidationError", "message": "message error"}],
+        )


### PR DESCRIPTION
This makes it possible for the error message to reach the client as an object, avoiding the need for string-to-object conversions.

https://github.com/plone/plone.restapi/pull/1755 needs to be merge first.

Fixes #176 